### PR TITLE
fix(lucene-query-factory): eitherOr query fails with undefined values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this
 file. File structured according to <http://keepachangelog.com/>
 
+## 0.7.1 - 02-03-15
+- fix: eitherOr query fails with undefined values
+
 ## 0.7.0 - 27-02.15
 - add ability to pass paginator options through query-factory
 

--- a/dist/ehealth-couch-query.js
+++ b/dist/ehealth-couch-query.js
@@ -2153,7 +2153,9 @@ angular
           getSearchExpression: function() {
             var terms = Object.keys(fields).map(function (key) {
               function addLabel(key, value) {
-                value = value || fields[key].value;
+                if (angular.isUndefined(value)) {
+                  value = fields[key].value;
+                }
                 var queryValue = angular.isArray(value) ?
                   '(' + value.map(foldToAscii).join(' OR ') + ')' :
                   foldToAscii(value);
@@ -2162,7 +2164,9 @@ angular
               if (fields[key].type === 'not') {
                 return 'NOT '+addLabel(key);
               } else if (fields[key].type === 'eitherOr') {
-                var labeled = Object.keys(fields[key].value).map(function(k) {
+                var labeled = Object.keys(fields[key].value).filter(function(k) {
+                  return angular.isDefined(fields[key].value[k]);
+                }).map(function(k) {
                   return addLabel(k, fields[key].value[k]);
                 });
                 return labeled.length ? '(' + labeled.join(' OR ') + ')' : '';

--- a/src/eHealth.couchQuery/services/lucene-query-factory.js
+++ b/src/eHealth.couchQuery/services/lucene-query-factory.js
@@ -65,7 +65,9 @@ angular
           getSearchExpression: function() {
             var terms = Object.keys(fields).map(function (key) {
               function addLabel(key, value) {
-                value = value || fields[key].value;
+                if (angular.isUndefined(value)) {
+                  value = fields[key].value;
+                }
                 var queryValue = angular.isArray(value) ?
                   '(' + value.map(foldToAscii).join(' OR ') + ')' :
                   foldToAscii(value);
@@ -74,7 +76,9 @@ angular
               if (fields[key].type === 'not') {
                 return 'NOT '+addLabel(key);
               } else if (fields[key].type === 'eitherOr') {
-                var labeled = Object.keys(fields[key].value).map(function(k) {
+                var labeled = Object.keys(fields[key].value).filter(function(k) {
+                  return angular.isDefined(fields[key].value[k]);
+                }).map(function(k) {
                   return addLabel(k, fields[key].value[k]);
                 });
                 return labeled.length ? '(' + labeled.join(' OR ') + ')' : '';

--- a/test/unit/eHealth.couchQuery/services/lucene-query-factory.js
+++ b/test/unit/eHealth.couchQuery/services/lucene-query-factory.js
@@ -261,9 +261,12 @@ describe('Service: luceneQueryFactory', function () {
   });
   describe('a query that match one of multiple key value pairs (eitherOr query)', function() {
     it ('generates the expected expression with simple fields', function() {
-      query.searchFieldEitherOr('createdBy', {'contact_createdby_username': 'username', 'contact_createdby': 'name' });
+      query.searchFieldEitherOr('createdBy', {
+        'contact_createdby_username': 'username',
+        'contact_createdby': 'name',
+        'createdby': 'username'});
       expect(query.getSearchExpression())
-        .toBe('(contact_createdby_username:username OR contact_createdby:name)');
+        .toBe('(contact_createdby_username:username OR contact_createdby:name OR createdby:username)');
     });
     it ('generates the expected expression with multiple fields', function() {
       var users = ['user1', 'user2'];
@@ -273,6 +276,13 @@ describe('Service: luceneQueryFactory', function () {
       });
       expect(query.getSearchExpression())
         .toBe('(contact_createdby_username:(user1 OR user2) OR contact_createdby:(user1 OR user2))');
+    });
+    it('doesn\'t add a search field when the value is undefined', function() {
+      query.searchFieldEitherOr('createdBy', {
+        'contact_createdby_username': undefined,
+        'createdby': 'username'});
+      expect(query.getSearchExpression())
+        .toBe('(createdby:username)');
     });
     it('allows to clear the field', function(){
       query.searchFieldEitherOr('createdBy', {});


### PR DESCRIPTION
A exception was thrown when calling `query.searchFieldEitherOr` providing
an undefined value for any of the query fields.
Ex: `query.searchFieldEitherOr('test', {'test1': 'test', 'test2': undefined})
This has been fixed to ignore the fields with undefined as search value.
